### PR TITLE
Add generation config for Gemini

### DIFF
--- a/gemini/pyproject.toml
+++ b/gemini/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "restack_integrations_gemini"
-version = "0.0.4"
+version = "0.0.6"
 description = "Gemini integration for Restack AI"
 authors = [
     "Restack Team <service@restack.io>"

--- a/gemini/src/restack_integrations_gemini/functions/generate_content.py
+++ b/gemini/src/restack_integrations_gemini/functions/generate_content.py
@@ -5,6 +5,7 @@ class GeminiGenerateContentInput(BaseModel):
     user_content: str
     model: str | None = None
     api_key: str = ""
+    generation_config: dict | None = None
 
 def gemini_generate_content(input) :
     if not input.api_key:
@@ -14,7 +15,7 @@ def gemini_generate_content(input) :
 
     model = genai.GenerativeModel(model_name=input.model)
 
-    response = model.generate_content(input.user_content)
+    response = model.generate_content(input.user_content, generation_config=genai.GenerationConfig(**input.generation_config))
 
     return response.text
 


### PR DESCRIPTION
Enable usage of `generation_config` when generating content
Bump the version number